### PR TITLE
Fix .gitattributes and text encoding

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+*.bas -text working-tree-encoding=CP950
+*.cls -text working-tree-encoding=CP950
+*.frm -text working-tree-encoding=CP950

--- a/Module2.bas
+++ b/Module2.bas
@@ -1,4 +1,4 @@
 Attribute VB_Name = "Module2"
 Sub ShowCompareForm()
-    UserForm2.Show vbModeless ' «D¼ÒºA¡A¤¹³\¦P®É¾Ş§@ Word
+    UserForm2.Show vbModeless ' éæ¨¡æ…‹ï¼Œå…è¨±åŒæ™‚æ“ä½œ Word
 End Sub


### PR DESCRIPTION
In this PR I used `-text` to avoid line ending conversions since your files already have the correct line endings. I also used `working-tree-encoding=CP950` because `CP950` = [Code page 950](https://en.wikipedia.org/wiki/Code_page_950) is the code page used on Microsoft Windows for Traditional Chinese.

Fixes https://github.com/DecimalTurn/VBA-GitHub-Checks/issues/733